### PR TITLE
Tiered evolution

### DIFF
--- a/v2/simulation/action.go
+++ b/v2/simulation/action.go
@@ -1,30 +1,47 @@
 package simulation
 
 const (
+	// -- Tier 1 --
+
 	// Positive = accelerate forward, negative = decelerate/reverse.
 	ACCELERATE byte = iota
 	// Positive = turn left (CCW), negative = turn right (CW).
 	ROTATE
-	// Triggers reproduction this tick: asexual splits a daughter cell; sexual seeks a mate.
-	REPRODUCE
+
+	// -- Tier 2 --
+
 	// Adjusts the period of the OSC1 oscillator each tick.
 	SET_OSCILLATOR_PERIOD
+	// Reduces energy expenditure; creature conserves energy while resting.
+	REST
+
+	// -- Tier 3 --
+
+	// Attacks the nearest lighter creature ahead; transfers mass on a successful hit.
+	ATTACK
+	// Triggers reproduction this tick: asexual splits a daughter cell; sexual seeks a mate.
+	REPRODUCE
+
+	// -- Tier 4 --
+
+	// Donates stomach contents proportional to action level to the nearest touching creature ahead.
+	FEED
 	// Scales the creature's responsiveness, amplifying or dampening all sensor signals.
 	SET_RESPONSIVENESS
 	// Modulates per-tick learning rate relative to the genome baseline.
 	SET_LEARNING_RATE
-	// Reduces energy expenditure; creature conserves energy while resting.
-	REST
-	// Attacks the nearest lighter creature ahead; transfers mass on a successful hit.
-	ATTACK
 	// Sends a reward signal to the nearest touching creature ahead.
 	REWARD
 	// Sends a punishment signal to the nearest touching creature ahead.
 	PUNISH
-	// Donates stomach contents proportional to action level to the nearest touching creature ahead.
-	FEED
 
 	ACTION_COUNT
+)
+
+const (
+	MaxTier1Action = 1
+	MaxTier2Action = 3
+	MaxTier3Action = 5
 )
 
 func IsActionEnabled(a byte) bool {

--- a/v2/simulation/creature.go
+++ b/v2/simulation/creature.go
@@ -371,7 +371,7 @@ func (c Creature) MaxAge(params *Parameters) int {
 	return int((baseLife * sizeMult) / metabolicPenalty)
 }
 
-func (c *Creature) CalculateGenerationBonus() float32 {
+func (c *Creature) CalculateGenerationBonus(params *Parameters) float32 {
 	massRatio := c.Mass / c.MaxMass
 	if massRatio > 1.0 {
 		massRatio = 1.0
@@ -379,11 +379,11 @@ func (c *Creature) CalculateGenerationBonus() float32 {
 
 	// High-performance squared growth factor
 	growthFactor := massRatio * massRatio
-
+	maxAge := float32(c.MaxAge(params))
 	// Longevity factor scales up if they lived past their juvenile threshold
 	longevityFactor := float32(1.0)
-	if c.cachedJuvenilePeriod > 0 && c.Age > c.cachedJuvenilePeriod {
-		longevityFactor = float32(c.Age) / float32(c.cachedJuvenilePeriod)
+	if maxAge > 0 {
+		longevityFactor = float32(c.Age) / maxAge
 	}
 
 	deltaGen := growthFactor * longevityFactor

--- a/v2/simulation/creature.go
+++ b/v2/simulation/creature.go
@@ -23,7 +23,7 @@ type simCacheEntry struct {
 
 type Creature struct {
 	Id             int
-	Generation     int
+	Generation     float32
 	Energy         float32
 	LastTickEnergy float32
 	Responsiveness float32
@@ -49,6 +49,7 @@ type Creature struct {
 	IsResting      bool
 	Color          color.RGBA
 	Radius         float32
+	Tier           byte
 
 	// Genome-derived constants cached at construction to avoid recomputing each tick.
 	halfFOVCos           float32 // math.Cos(FieldOfView/2 in radians)
@@ -71,15 +72,16 @@ type Creature struct {
 func NewCreature(id int, loc world.Position, g *Genome, p *Parameters) *Creature {
 	g.recomputeBytes()
 	c := Creature{
-		Id:             id,
-		Generation:     1,
-		Age:            0,
-		Alive:          true,
-		Clock:          int(g.OscPeriod),
-		Nnet:           NeuralNet{},
-		Loc:            loc,
-		BirthLoc:       loc,
-		Responsiveness: float32(utils.LerpByteAsFloat32(0, 1, g.Responsiveness)) / 2,
+		Id:         id,
+		Generation: 1.0,
+		Age:        0,
+		Alive:      true,
+		Clock:      int(g.OscPeriod),
+		Nnet:       NeuralNet{},
+		Loc:        loc,
+		BirthLoc:   loc,
+		// Responsiveness: utils.LerpByteAsFloat32(0, 1, g.Responsiveness),
+		Responsiveness: 1.0,
 		Heading:        float32(rand.Float64()*2*math.Pi - math.Pi),
 		Genome:         g,
 	}
@@ -93,21 +95,23 @@ func NewCreature(id int, loc world.Position, g *Genome, p *Parameters) *Creature
 	c.CreateNeuralNet()
 	c.Color = c.CalculateColor(p)
 	c.UpdateSize(p)
+	c.Tier = GetTierFromGeneration(c.Generation, p)
 	return &c
 }
 
 func NewAdultCreature(id int, loc world.Position, g *Genome, p *Parameters) *Creature {
 	g.recomputeBytes()
 	c := Creature{
-		Id:             id,
-		Generation:     1,
-		Age:            0,
-		Alive:          true,
-		Clock:          int(g.OscPeriod),
-		Nnet:           NeuralNet{},
-		Loc:            loc,
-		BirthLoc:       loc,
-		Responsiveness: float32(utils.LerpByteAsFloat32(0, 1, g.Responsiveness)) / 2,
+		Id:         id,
+		Generation: 1.0,
+		Age:        0,
+		Alive:      true,
+		Clock:      int(g.OscPeriod),
+		Nnet:       NeuralNet{},
+		Loc:        loc,
+		BirthLoc:   loc,
+		// Responsiveness: utils.LerpByteAsFloat32(0, 1, g.Responsiveness),
+		Responsiveness: 1.0,
 		Heading:        float32(rand.Float64()*2*math.Pi - math.Pi),
 		Genome:         g,
 	}
@@ -121,6 +125,7 @@ func NewAdultCreature(id int, loc world.Position, g *Genome, p *Parameters) *Cre
 	c.Age = c.cachedJuvenilePeriod
 	c.Color = c.CalculateColor(p)
 	c.UpdateSize(p)
+	c.Tier = GetTierFromGeneration(c.Generation, p)
 	return &c
 }
 
@@ -285,6 +290,7 @@ func (c *Creature) GrowMass(params *Parameters) {
 		energyFactor = (energyRatio - 0.2) / 0.8
 	}
 	massRatio := float64(c.Mass) / float64(maxMass)
+
 	// von Bertalanffy rate: peaks at massRatio ≈ 0.33, zero at 0 and 1.
 	growthRate := float64(params.MaxGrowthRatePerTick) * math.Sqrt(massRatio) * (1.0 - massRatio)
 	actualGrowth := growthRate * energyFactor
@@ -363,6 +369,29 @@ func (c Creature) MaxAge(params *Parameters) int {
 	metabolicGeneNorm := float32(c.Genome.MetabolicRate) / 255.0
 	metabolicPenalty := 0.75 + metabolicGeneNorm // [0.75, 1.75]
 	return int((baseLife * sizeMult) / metabolicPenalty)
+}
+
+func (c *Creature) CalculateGenerationBonus() float32 {
+	massRatio := c.Mass / c.MaxMass
+	if massRatio > 1.0 {
+		massRatio = 1.0
+	}
+
+	// High-performance squared growth factor
+	growthFactor := massRatio * massRatio
+
+	// Longevity factor scales up if they lived past their juvenile threshold
+	longevityFactor := float32(1.0)
+	if c.cachedJuvenilePeriod > 0 && c.Age > c.cachedJuvenilePeriod {
+		longevityFactor = float32(c.Age) / float32(c.cachedJuvenilePeriod)
+	}
+
+	deltaGen := growthFactor * longevityFactor
+	if deltaGen > 2.0 {
+		deltaGen = 2.0
+	}
+
+	return deltaGen
 }
 
 func calculateFunctionalIntelligence(nn *NeuralNet, g *Genome) float32 {

--- a/v2/simulation/generation.go
+++ b/v2/simulation/generation.go
@@ -1,0 +1,23 @@
+package simulation
+
+// GetTierFromGeneration returns a tier (0–3) based on per-tier generation thresholds.
+func GetTierFromGeneration(generation float32, p *Parameters) byte {
+	currentGenProgress := int(generation)
+	switch {
+	case currentGenProgress >= p.Tier4Generation:
+		return 3
+	case currentGenProgress >= p.Tier3Generation:
+		return 2
+	case currentGenProgress >= p.Tier2Generation:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func getTierBoundaries(generation float32, p *Parameters) (byte, byte) {
+	tier := GetTierFromGeneration(generation, p)
+	minBound := tier * 64
+	maxBound := minBound + 63
+	return minBound, maxBound
+}

--- a/v2/simulation/genome.go
+++ b/v2/simulation/genome.go
@@ -191,28 +191,65 @@ func makeRandomBool() byte {
 }
 
 // MakeRandomGene creates a random gene
-func MakeRandomGene() Gene {
+func MakeRandomGene(allowedSensors, allowedActions, cognitiveBreadth byte) Gene {
+	sourceType := byte(SENSOR)
+	var sourceID byte
+
+	// Single random byte for both structural type flags
+	typeFlags := utils.MakeRandomByte()
+
+	if cognitiveBreadth > 0 && (typeFlags&1) == 1 {
+		sourceType = NEURON
+		sourceID = utils.MakeRandomByte() % cognitiveBreadth
+	} else {
+		sourceID = utils.MakeRandomByte() % allowedSensors
+	}
+
+	sinkType := byte(ACTION)
+	var sinkID byte
+	if cognitiveBreadth > 0 && ((typeFlags>>1)&1) == 1 {
+		sinkType = NEURON
+		sinkID = utils.MakeRandomByte() % cognitiveBreadth
+	} else {
+		sinkID = utils.MakeRandomByte() % allowedActions
+	}
 	return Gene{
-		SourceType: utils.MakeRandomByte() & 1,
-		SourceID:   utils.MakeRandomByte(),
-		SinkType:   byte(rand.Intn(2) * 2),
-		SinkID:     utils.MakeRandomByte(),
+		SourceType: sourceType,
+		SourceID:   sourceID,
+		SinkType:   sinkType,
+		SinkID:     sinkID,
 		Weight:     utils.MakeRandomByte(),
 	}
 }
 
-func MakeRandomGenome(p *Parameters) *Genome {
+func MakeRandomGenome(p *Parameters, tier byte) *Genome {
 	// Mass must be >= 3 to guarantee a valid MinMass (MinMass < Mass/2 requires Mass > 2).
+	massByte := utils.MakeRandomByte()
+	if massByte < 3 {
+		massByte = 3
+	}
+
+	// Generation
+	// 1. Calculate Tier-Constrained Cognitive Breadth (Split 0-255 into 4 parts)
+	// Tier 0: 0-63, Tier 1: 64-127, Tier 2: 128-191, Tier 3: 192-255
+	minBreadth := tier * 64
+	maxBreadth := minBreadth + 63
+	cogBreadth := utils.LerpByte(minBreadth, maxBreadth, utils.MakeRandomByte())
+	// Scale SynapticDensity alongside tear
+	minDensity := utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, tier*64)
+	maxDensity := utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, (tier+1)*64-1)
+	synDensity := utils.LerpByte(minDensity, maxDensity, utils.MakeRandomByte())
+
 	g := Genome{
-		OscPeriod:        utils.LerpByte(1, math.MaxUint8, utils.MakeRandomByte()),
-		SightDistance:    utils.MakeRandomByte(),
-		FieldOfView:      utils.MakeRandomByte(),
-		Responsiveness:   utils.MakeRandomByte(),
-		MutationRate:     utils.LerpByte(1, math.MaxUint8, utils.MakeRandomByte()),
-		Mass:             utils.MakeRandomByte(),
-		ReproductionType: makeRandomBool(),
-		CognitiveBreadth:  utils.LerpByte(p.MinCognitiveBreadth, p.MaxCognitiveBreadth, utils.MakeRandomByte()),
-		SynapticDensity:   utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, utils.MakeRandomByte()),
+		OscPeriod:         utils.LerpByte(1, math.MaxUint8, utils.MakeRandomByte()),
+		SightDistance:     utils.MakeRandomByte(),
+		FieldOfView:       utils.MakeRandomByte(),
+		Responsiveness:    utils.MakeRandomByte(),
+		MutationRate:      utils.LerpByte(1, math.MaxUint8, utils.MakeRandomByte()),
+		Mass:              massByte,
+		ReproductionType:  makeRandomBool(),
+		CognitiveBreadth:  cogBreadth,
+		SynapticDensity:   synDensity,
 		JuvenilePeriod:    utils.MakeRandomByte(),
 		MetabolicRate:     utils.MakeRandomByte(),
 		StomachSize:       utils.MakeRandomByte(),
@@ -226,8 +263,15 @@ func MakeRandomGenome(p *Parameters) *Genome {
 		maxMinMass = 1
 	}
 	g.MinMass = utils.LerpByte(1, maxMinMass, utils.MakeRandomByte())
+
+	// Allocate
+	g.Brain = make([]Gene, 0, g.SynapticDensity)
+
+	allowedSensors := getAllowedSensorCount(g.CognitiveBreadth)
+	allowedActions := getAllowedActionCount(g.CognitiveBreadth)
+
 	for i := byte(0); i < g.SynapticDensity; i++ {
-		gene := MakeRandomGene()
+		gene := MakeRandomGene(allowedSensors, allowedActions, g.CognitiveBreadth)
 		g.Brain = append(g.Brain, gene)
 	}
 	g.recomputeBytes()
@@ -264,7 +308,7 @@ func nudgeByte(val byte, strength int) byte {
 
 // Mutate randomly mutates genes in the genome at a rate of p.BaseMutationRate * g.MutationRate * radiationMult.
 // Pass radiationMult=1.0 for normal reproduction; pass params.RadiationMutationMultiplier for irradiated parents.
-func Mutate(g *Genome, p *Parameters, isArtificial bool, radiationMult float32) {
+func Mutate(g *Genome, p *Parameters, isArtificial bool, radiationMult float32, childGeneration float32) {
 	rateMultiplier := float32(g.MutationRate) / 128.0
 	mutationRate := p.BaseMutationRate * rateMultiplier * radiationMult
 
@@ -297,8 +341,13 @@ func Mutate(g *Genome, p *Parameters, isArtificial bool, radiationMult float32) 
 		g.ReproductionType ^= 1
 	}
 
-	mutateTarget(&g.CognitiveBreadth, p.MinCognitiveBreadth, p.MaxCognitiveBreadth, 5)
-	mutateTarget(&g.SynapticDensity, p.MinSynapticDensity, p.MaxSynapticDensity, 5)
+	minTierBreadth, maxTierBreadth := getTierBoundaries(childGeneration, p)
+	mutateTarget(&g.CognitiveBreadth, minTierBreadth, maxTierBreadth, 5)
+	// Force SynapticDensity bounds to slide up with the tier scaling
+	minDensity := utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, minTierBreadth)
+	maxDensity := utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, maxTierBreadth)
+	mutateTarget(&g.SynapticDensity, minDensity, maxDensity, 5)
+
 	mutateTarget(&g.JuvenilePeriod, 0, 255, 15)
 	mutateTarget(&g.MetabolicRate, 0, 255, 15)
 	mutateTarget(&g.StomachSize, 0, 255, 15)
@@ -306,6 +355,9 @@ func Mutate(g *Genome, p *Parameters, isArtificial bool, radiationMult float32) 
 	mutateTarget(&g.LearningThreshold, 0, 255, 10)
 	mutateTarget(&g.MassSplitRatio, 0, 255, 15)
 	mutateTarget(&g.DigestionType, 0, 255, 15)
+
+	allowedSensors := getAllowedSensorCount(g.CognitiveBreadth)
+	allowedActions := getAllowedActionCount(g.CognitiveBreadth)
 
 	for j := 0; j < len(g.Brain); j++ {
 		if rand.Float32() < mutationRate {
@@ -320,29 +372,45 @@ func Mutate(g *Genome, p *Parameters, isArtificial bool, radiationMult float32) 
 					g.Brain[j].SinkType = 2
 				}
 			case chance < 0.15:
-				g.Brain[j].SourceID = utils.MakeRandomByte()
+				if g.Brain[j].SourceType == 1 && g.CognitiveBreadth > 0 { // NEURON
+					g.Brain[j].SourceID = utils.MakeRandomByte() % g.CognitiveBreadth
+				} else { // SENSOR
+					g.Brain[j].SourceID = utils.MakeRandomByte() % allowedSensors
+				}
 			case chance < 0.20:
-				g.Brain[j].SinkID = utils.MakeRandomByte()
+				if g.Brain[j].SinkType == 1 && g.CognitiveBreadth > 0 { // NEURON
+					g.Brain[j].SinkID = utils.MakeRandomByte() % g.CognitiveBreadth
+				} else { // ACTION
+					g.Brain[j].SinkID = utils.MakeRandomByte() % allowedActions
+				}
 			default:
 				g.Brain[j].Weight = nudgeByte(g.Brain[j].Weight, 25)
 			}
 		}
 	}
+	// Brain expansion padding loop: fills vacant structural space when SynapticDensity scales upwards.
 	diff := int(g.SynapticDensity) - len(g.Brain)
 	if diff > 0 {
 		for i := 0; i < diff; i++ {
 			if len(g.Brain) > 0 && rand.Float32() < 0.8 {
-				// Pick a random existing gene and nudge it slightly.
 				newGene := g.Brain[rand.Intn(len(g.Brain))]
 				if rand.Float32() < 0.5 {
-					newGene.SourceID = utils.MakeRandomByte()
+					if newGene.SourceType == 1 && g.CognitiveBreadth > 0 {
+						newGene.SourceID = utils.MakeRandomByte() % g.CognitiveBreadth
+					} else {
+						newGene.SourceID = utils.MakeRandomByte() % allowedSensors
+					}
 				} else {
-					newGene.SinkID = utils.MakeRandomByte()
+					if newGene.SinkType == 1 && g.CognitiveBreadth > 0 {
+						newGene.SinkID = utils.MakeRandomByte() % g.CognitiveBreadth
+					} else {
+						newGene.SinkID = utils.MakeRandomByte() % allowedActions
+					}
 				}
 				newGene.Weight = nudgeByte(newGene.Weight, 40)
 				g.Brain = append(g.Brain, newGene)
 			} else {
-				g.Brain = append(g.Brain, MakeRandomGene())
+				g.Brain = append(g.Brain, MakeRandomGene(allowedSensors, allowedActions, g.CognitiveBreadth))
 			}
 		}
 	}
@@ -368,7 +436,7 @@ func pickGene(a, b Gene) Gene {
 // genes in the overlapping range are drawn from either parent; excess genes from
 // the longer parent survive with 50% probability.
 // radiationMult amplifies the mutation rate; pass 1.0 for normal conditions.
-func Crossover(g1, g2 *Genome, p *Parameters, radiationMult float32) *Genome {
+func Crossover(g1, g2 *Genome, p *Parameters, radiationMult float32, childGeneration float32) *Genome {
 	child := &Genome{
 		OscPeriod:         pickByte(g1.OscPeriod, g2.OscPeriod),
 		SightDistance:     pickByte(g1.SightDistance, g2.SightDistance),
@@ -384,6 +452,14 @@ func Crossover(g1, g2 *Genome, p *Parameters, radiationMult float32) *Genome {
 		LearningThreshold: pickByte(g1.LearningThreshold, g2.LearningThreshold),
 		MassSplitRatio:    pickByte(g1.MassSplitRatio, g2.MassSplitRatio),
 		DigestionType:     pickByte(g1.DigestionType, g2.DigestionType),
+	}
+
+	// If parents from different tiers cross over, force child into its generation tier bounds
+	minTierBreadth, maxTierBreadth := getTierBoundaries(childGeneration, p)
+	if child.CognitiveBreadth < minTierBreadth {
+		child.CognitiveBreadth = minTierBreadth
+	} else if child.CognitiveBreadth > maxTierBreadth {
+		child.CognitiveBreadth = maxTierBreadth
 	}
 
 	// --- GROUPED TRAITS ---
@@ -434,23 +510,20 @@ func Crossover(g1, g2 *Genome, p *Parameters, radiationMult float32) *Genome {
 	child.SynapticDensity = byte(targetLen)
 	mutationChance := 0.01 * radiationMult
 	if rand.Float32() < mutationChance {
-		Mutate(child, p, false, radiationMult)
+		Mutate(child, p, false, radiationMult, childGeneration)
 	}
 	return child
 }
 
 // AsexualReproduction creates a deep copy of the parent genome then mutates it.
 // radiationMult amplifies the mutation rate; pass 1.0 for normal conditions.
-func AsexualReproduction(parent *Genome, p *Parameters, radiationMult float32) *Genome {
+func AsexualReproduction(parent *Genome, p *Parameters, radiationMult float32, childGeneration float32) *Genome {
 	child := parent.Copy()
-	Mutate(child, p, false, radiationMult)
-	return child
-}
-
-// ArtificialReproduction creates a deep copy of the parent genome then mutates it by the spawn mutation rate.
-func ArtificialReproduction(parent *Genome, p *Parameters) *Genome {
-	child := parent.Copy()
-	Mutate(child, p, true, 1.0)
+	minTierBreadth, _ := getTierBoundaries(childGeneration, p)
+	if child.CognitiveBreadth < minTierBreadth {
+		child.CognitiveBreadth = minTierBreadth // Push up to the new tier minimum
+	}
+	Mutate(child, p, false, radiationMult, childGeneration)
 	return child
 }
 
@@ -501,4 +574,34 @@ func MapGeneToRange(gene byte, minRange, maxRange float64) float64 {
 
 	// 2. Map that percentage to the [min, max] range
 	return minRange + (percentage * (maxRange - minRange))
+}
+
+func IsSensorAllowed(sensorID byte, breadth byte) bool {
+	// Tier 1 always allowed (Breadth >= 0)
+	if sensorID <= MaxTier1Sensor {
+		return true
+	}
+	// Tier 2 requires ~25% cognitive breadth
+	if sensorID <= MaxTier2Sensor && breadth >= 64 {
+		return true
+	}
+	// Tier 3 requires ~50% cognitive breadth
+	if sensorID <= MaxTier3Sensor && breadth >= 128 {
+		return true
+	}
+	// Tier 4 requires ~75% cognitive breadth
+	return breadth >= 192
+}
+
+func IsActionAllowed(actionID byte, breadth byte) bool {
+	if actionID <= MaxTier1Action {
+		return true
+	}
+	if actionID <= MaxTier2Action && breadth >= 64 {
+		return true
+	}
+	if actionID <= MaxTier3Action && breadth >= 128 {
+		return true
+	}
+	return breadth >= 192
 }

--- a/v2/simulation/neuron.go
+++ b/v2/simulation/neuron.go
@@ -72,28 +72,45 @@ func (n NodeMap) String() string {
 
 func CreateInitialNeuronOutput() float32 { return 0.5 }
 
-func CreateNeuralNetworkFromGenome(genes []Gene, CognitiveBreadth byte) *NeuralNet {
-	neuralGenes := convertGenesToNeuronIDs(genes, CognitiveBreadth)
+func CreateNeuralNetworkFromGenome(genes []Gene, cognitiveBreadth byte) *NeuralNet {
+	neuralGenes := convertGenesToNeuronIDs(genes, cognitiveBreadth)
 	nodeMap := createNodeMap(neuralGenes)
 	finalGenes := removeUselessGenes(neuralGenes, nodeMap)
 	// The remaining nodes in nodeMap will need to be re-indexed
 	setNodeNewIDValues(nodeMap)
-	neuralNet := createNeuralNetworkFromGenesAndNodeMap(finalGenes, nodeMap)
+	neuralNet := createNeuralNetworkFromGenesAndNodeMap(finalGenes, nodeMap, cognitiveBreadth)
 	return neuralNet
 }
 
-func createNeuralNetworkFromGenesAndNodeMap(g []Gene, n NodeMap) *NeuralNet {
+func createNeuralNetworkFromGenesAndNodeMap(g []Gene, n NodeMap, cognitiveBreadth byte) *NeuralNet {
 	nnet := NeuralNet{}
 	nnet.Weights = make([]float32, len(g))
+
+	allowedSensorCount := getAllowedSensorCount(cognitiveBreadth)
+	allowedActionCount := getAllowedActionCount(cognitiveBreadth)
 
 	// Two-pass: neuron-sink edges first, then action-sink.
 	edgeIndex := 0
 	for _, gene := range g {
 		if gene.SinkType == NEURON {
-			gene.SinkID = n[gene.SinkID].NewID
-			if gene.SourceType == NEURON {
-				gene.SourceID = n[gene.SourceID].NewID
+			// Skip pruned in nMap
+			node, ok := n[gene.SinkID]
+			if !ok {
+				continue
 			}
+			gene.SinkID = node.NewID
+
+			if gene.SourceType == NEURON {
+				if srcNode, srcOk := n[gene.SourceID]; srcOk {
+					gene.SourceID = srcNode.NewID
+				} else {
+					continue // Prune if driving neuron doesn't exist
+				}
+			} else {
+				// Clamp sensor access to currently allowed tier bounds
+				gene.SourceID %= allowedSensorCount
+			}
+
 			nnet.Edges = append(nnet.Edges, gene)
 			nnet.Weights[edgeIndex] = gene.WeightAsFloat32()
 			edgeIndex++
@@ -102,9 +119,20 @@ func createNeuralNetworkFromGenesAndNodeMap(g []Gene, n NodeMap) *NeuralNet {
 	nnet.NeuronEdgeCount = edgeIndex
 	for _, gene := range g {
 		if gene.SinkType == ACTION {
+			// Clamp target actions to currently allowed tier bounds
+			gene.SinkID %= allowedActionCount
+
 			if gene.SourceType == NEURON {
-				gene.SourceID = n[gene.SourceID].NewID
+				if srcNode, srcOk := n[gene.SourceID]; srcOk {
+					gene.SourceID = srcNode.NewID
+				} else {
+					continue // Prune if driving neuron doesn't exist
+				}
+			} else {
+				// Clamp sensor access to currently allowed tier bounds
+				gene.SourceID %= allowedSensorCount
 			}
+
 			nnet.Edges = append(nnet.Edges, gene)
 			nnet.Weights[edgeIndex] = gene.WeightAsFloat32()
 			edgeIndex++
@@ -115,20 +143,21 @@ func createNeuralNetworkFromGenesAndNodeMap(g []Gene, n NodeMap) *NeuralNet {
 	nnet.HiddenNeurons = make([]Neuron, len(n))
 	for _, node := range n {
 		nnet.HiddenNeurons[node.NewID] = Neuron{
-			Output:      CreateInitialNeuronOutput(),
-			Driven:      node.InputCount != 0,
-			Sensitivity: 1.0,
+			Output:        CreateInitialNeuronOutput(),
+			Driven:        node.InputCount != 0,
+			AverageOutput: CreateInitialNeuronOutput(), // Matches your updated struct
+			Sensitivity:   1.0,
 		}
 	}
-
 	// Record which sensors are actually wired in so FeedForward can pre-compute
 	// them once rather than calling GetSensor once per edge.
 	for i := range nnet.Edges {
 		if nnet.Edges[i].SourceType == SENSOR {
+			// Because of the modulo guard rails above, this index is guaranteed
+			// to fall safely within fixed [SENSOR_COUNT]bool boundaries.
 			nnet.ActiveSensors[nnet.Edges[i].SourceID] = true
 		}
 	}
-
 	return &nnet
 }
 
@@ -149,6 +178,8 @@ func setNodeNewIDValues(n NodeMap) {
 		node.NewID = byte(i)
 	}
 }
+
+// removeUselessGenes iteratively purges non-functional neurons and dead connections from the network.
 func removeUselessGenes(g []Gene, n NodeMap) []Gene {
 	if len(n) == 0 {
 		return g
@@ -159,7 +190,7 @@ func removeUselessGenes(g []Gene, n NodeMap) []Gene {
 	for !done {
 		done = true
 
-		// 1. Extract and sort keys to ensure deterministic pruning
+		// Extract and sort keys to ensure deterministic pruning
 		keys := make([]byte, 0, len(n))
 		for k := range n {
 			keys = append(keys, k)
@@ -168,7 +199,6 @@ func removeUselessGenes(g []Gene, n NodeMap) []Gene {
 			return keys[i] < keys[j]
 		})
 
-		// 2. Iterate through sorted keys
 		for _, key := range keys {
 			node, exists := n[key]
 			if !exists {
@@ -191,6 +221,8 @@ func removeUselessGenes(g []Gene, n NodeMap) []Gene {
 	return final
 }
 
+// removeConnectionsToGene removes all edges that sink (target) into the specified neuron key.
+// It simultaneously updates the OutputCount metrics of any upstream hidden neurons that were driving it.
 func removeConnectionsToGene(genes []Gene, n NodeMap, key byte) []Gene {
 	newGenes := genes[:0]
 
@@ -199,33 +231,38 @@ func removeConnectionsToGene(genes []Gene, n NodeMap, key byte) []Gene {
 		if gene.SinkType == NEURON && gene.SinkID == key {
 			// ...then the source of this gene just lost an output.
 			if gene.SourceType == NEURON {
-				if sourceNode, exists := n[gene.SourceID]; exists {
-					if sourceNode.OutputCount > 0 {
-						sourceNode.OutputCount--
-					}
+				if gene.SourceID != key {
 					// Handle self-loop decrement if the neuron is pruning itself
-					if gene.SourceID == key && sourceNode.SelfLoopCount > 0 {
-						sourceNode.SelfLoopCount--
+					if sourceNode, exists := n[gene.SourceID]; exists {
+						if sourceNode.OutputCount > 0 {
+							sourceNode.OutputCount--
+						}
 					}
 				}
 			}
 			// Do NOT append this gene; it is now deleted.
 			continue
 		}
-
 		// Keep genes that don't point to the deleted neuron.
 		newGenes = append(newGenes, gene)
 	}
 	return newGenes
 }
 
+// removeOutgoingConnections removes all edges that source (originate) from the specified neuron key.
+// It simultaneously updates the InputCount metrics of any downstream hidden neurons receiving its signal.
 func removeOutgoingConnections(genes []Gene, n NodeMap, key byte) []Gene {
 	newGenes := genes[:0]
+
 	for _, gene := range genes {
 		if gene.SourceType == NEURON && gene.SourceID == key {
 			if gene.SinkType == NEURON {
-				if sinkNode, exists := n[gene.SinkID]; exists && sinkNode.InputCount > 0 {
-					sinkNode.InputCount--
+				if gene.SinkID != key {
+					if sinkNode, exists := n[gene.SinkID]; exists {
+						if sinkNode.InputCount > 0 {
+							sinkNode.InputCount--
+						}
+					}
 				}
 			}
 			continue
@@ -244,7 +281,16 @@ func TestRemoveList(g []Gene) []Gene {
 	return g
 }
 
-// createNodeMap takes in
+// createNodeMap analyzes the topology of the neural network by scanning all connections (edges).
+// It constructs a map tracking the structural characteristics of every unique hidden neuron found.
+//
+// This analysis is a prerequisite for network optimization:
+//  1. It identifies non-functional "dead-end" neurons (e.g., hidden neurons that receive sensor
+//     inputs but never output to anything, or neurons that output to actions but have no inputs).
+//  2. It separates true independent inputs from internal self-recurrent loops, allowing
+//     the system to track if a neuron is actively "driven" by external signals.
+//  3. It collects the raw structural layout needed to compact the surviving neuron IDs
+//     into a packed, contiguous memory space (0..N-1) for fast execution lookups.
 func createNodeMap(neuralGenes []Gene) NodeMap {
 	nMap := NodeMap{}
 	ensureNode := func(id byte) {
@@ -279,22 +325,65 @@ func createNodeMap(neuralGenes []Gene) NodeMap {
 	return nMap
 }
 
-func convertGenesToNeuronIDs(genes []Gene, CognitiveBreadth byte) []Gene {
+func convertGenesToNeuronIDs(genes []Gene, cognitiveBreadth byte) []Gene {
 	newGenes := make([]Gene, len(genes))
+
+	allowedSensorCount := getAllowedSensorCount(cognitiveBreadth)
+	allowedActionCount := getAllowedActionCount(cognitiveBreadth)
+
 	for i, g := range genes {
-		if g.SourceType == NEURON && CognitiveBreadth > 0 {
-			g.SourceID %= CognitiveBreadth
+		if g.SourceType == NEURON {
+			if cognitiveBreadth > 0 {
+				g.SourceID %= cognitiveBreadth
+			} else {
+				// Creature has no capacity for hidden neurons.
+				// Set ID to 0; createNodeMap will naturally prune this useless edge out.
+				g.SourceID = 0
+			}
 		} else {
-			g.SourceType = SENSOR
-			g.SourceID %= SENSOR_COUNT
+			// SENSOR
+			g.SourceID %= allowedSensorCount
 		}
-		if g.SinkType == NEURON && CognitiveBreadth > 0 {
-			g.SinkID %= CognitiveBreadth
+
+		if g.SinkType == NEURON {
+			if cognitiveBreadth > 0 {
+				g.SinkID %= cognitiveBreadth
+			} else {
+				// No hidden neuron capacity.
+				g.SinkID = 0
+			}
 		} else {
-			g.SinkType = ACTION
-			g.SinkID %= ACTION_COUNT
+			// ACTION
+			g.SinkID %= allowedActionCount
 		}
+
 		newGenes[i] = g
 	}
 	return newGenes
+}
+
+func getAllowedSensorCount(breadth byte) byte {
+	if breadth < 64 {
+		return MaxTier1Sensor + 1
+	}
+	if breadth < 128 {
+		return MaxTier2Sensor + 1
+	}
+	if breadth < 192 {
+		return MaxTier3Sensor + 1
+	}
+	return SENSOR_COUNT
+}
+
+func getAllowedActionCount(breadth byte) byte {
+	if breadth < 64 {
+		return MaxTier1Action + 1
+	}
+	if breadth < 128 {
+		return MaxTier2Action + 1
+	}
+	if breadth < 192 {
+		return MaxTier3Action + 1
+	}
+	return ACTION_COUNT
 }

--- a/v2/simulation/parameters.go
+++ b/v2/simulation/parameters.go
@@ -134,7 +134,7 @@ func DefaultParams() *Parameters {
 		MaxJuvenilePeriod:           1000,
 		MaxFood:                     50000,
 		FoodSpawnInterval:           10,
-		FoodMass:                    10.0,
+		FoodMass:                    5.0,
 		FountainCount:               20,
 		FountainDriftSpeed:          10,
 		FountainRadius:              200.0,

--- a/v2/simulation/parameters.go
+++ b/v2/simulation/parameters.go
@@ -96,6 +96,12 @@ type Parameters struct {
 	// Collisions
 	CollisionRepulsion float64 // fraction of overlap resolved per tick [0, 1]; 0 = disabled
 
+	// Generation tier thresholds
+	Tier1Generation int // generation at which tier 1 begins
+	Tier2Generation int // generation at which tier 2 begins
+	Tier3Generation int // generation at which tier 3 begins
+	Tier4Generation int // generation at which tier 4 begins
+
 	// Misc
 	SavedGenomeProportion  float64
 	PopulationSensorRadius float64
@@ -112,8 +118,8 @@ func DefaultParams() *Parameters {
 		MaxMass:                     750,
 		MinSpawnCognitiveBreadth:    15,
 		MaxSpawnCognitiveBreadth:    70,
-		MinCognitiveBreadth:         10,
-		MaxCognitiveBreadth:         75,
+		MinCognitiveBreadth:         0,
+		MaxCognitiveBreadth:         0,
 		MinSynapticDensity:          10,
 		MaxSynapticDensity:          100,
 		MinSightDistance:            50,
@@ -126,7 +132,7 @@ func DefaultParams() *Parameters {
 		BaseMaxAge:                  25000,
 		MinJuvenilePeriod:           300,
 		MaxJuvenilePeriod:           1000,
-		MaxFood:                     150000,
+		MaxFood:                     50000,
 		FoodSpawnInterval:           10,
 		FoodMass:                    10.0,
 		FountainCount:               20,
@@ -161,6 +167,10 @@ func DefaultParams() *Parameters {
 		RadiationDamagePerTick:      0.1,
 		CollisionRepulsion:          0.5,
 		SavedGenomeProportion:       0.05,
+		Tier1Generation:             0,
+		Tier2Generation:             2,
+		Tier3Generation:             50,
+		Tier4Generation:             100,
 	}
 	if err := p.Validate(); err != nil {
 		panic(err)

--- a/v2/simulation/population.go
+++ b/v2/simulation/population.go
@@ -415,7 +415,7 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 		if parent.Energy < params.ReproductionEnergyThreshold*parent.MaxEnergy(params) {
 			continue
 		}
-		if float64(parent.Mass) < float64(parent.Genome.Mass)*0.9 {
+		if parent.Mass < parent.MaxMass*0.9 {
 			continue
 		}
 		if float32(parent.Genome.MinMass)*2 >= float32(parent.Genome.Mass) {
@@ -431,7 +431,7 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 			if partner.Energy < params.ReproductionEnergyThreshold*partner.MaxEnergy(params) {
 				continue
 			}
-			if float64(partner.Mass) < float64(partner.Genome.Mass)*0.9 {
+			if partner.Mass < partner.MaxMass*0.9 {
 				continue
 			}
 
@@ -440,8 +440,14 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 				continue
 			}
 
+			// 1. Find the baseline mid-point of the parental lineages
+			baseGen := (parent.Generation + partner.Generation) * 0.5
+			bonusA := parent.CalculateGenerationBonus()
+			bonusB := partner.CalculateGenerationBonus()
+			childGen := baseGen + (bonusA+bonusB)*0.5
+
 			radMult := radiationMult(parent.Loc.X, params)
-			childGenome := Crossover(parent.Genome, partner.Genome, params, radMult)
+			childGenome := Crossover(parent.Genome, partner.Genome, params, radMult, childGen)
 			childStartingMass := float32(childGenome.Mass)
 
 			ratioA := 0.1 + (float32(parent.Genome.MassSplitRatio)/255.0)*0.4
@@ -468,7 +474,8 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 
 			id := w.AddCreature(offspringLoc)
 			child := NewCreature(id, offspringLoc, childGenome, params)
-			child.Generation = maxInt(parent.Generation, partner.Generation) + 1
+			child.Generation = childGen
+			child.Tier = GetTierFromGeneration(childGen, params)
 			child.GainEnergy(energyTransferred, params)
 			p.Creatures[id] = child
 			p.AddAlive(id)
@@ -485,16 +492,32 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 		childMass := parent.Mass * splitRatio
 		energyToSplit := parent.Energy * splitRatio
 		energyTransferred := energyToSplit * params.ReproductionEfficiency
+		massRatio := parent.Mass / parent.MaxMass
+		if massRatio > 1.0 {
+			massRatio = 1.0
+		}
+		growthFactor := massRatio * massRatio
+
+		// 3. Longevity factor scales above 1.0 if they outlived their juvenile period
+		longevityFactor := float32(1.0)
+		if parent.cachedJuvenilePeriod > 0 && parent.Age > parent.cachedJuvenilePeriod {
+			longevityFactor = float32(parent.Age) / float32(parent.cachedJuvenilePeriod)
+		}
+		deltaGen := growthFactor * longevityFactor
+		if deltaGen > 2.0 {
+			deltaGen = 2.0
+		}
+		childGen := parent.Generation + deltaGen
 
 		parent.Mass -= childMass
 		parent.UpdateSize(params)
 		parent.DrainEnergy(energyToSplit)
-
 		radMult := radiationMult(parent.Loc.X, params)
-		childGenome := AsexualReproduction(parent.Genome, params, radMult)
+		childGenome := AsexualReproduction(parent.Genome, params, radMult, childGen)
 		id := w.AddCreature(offspringLoc)
 		child := NewCreature(id, offspringLoc, childGenome, params)
-		child.Generation = parent.Generation + 1
+		child.Generation = parent.CalculateGenerationBonus()
+		child.Tier = GetTierFromGeneration(childGen, params)
 		child.Mass = childMass
 		child.UpdateSize(params)
 		child.Energy = energyTransferred

--- a/v2/simulation/population.go
+++ b/v2/simulation/population.go
@@ -442,8 +442,8 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 
 			// 1. Find the baseline mid-point of the parental lineages
 			baseGen := (parent.Generation + partner.Generation) * 0.5
-			bonusA := parent.CalculateGenerationBonus()
-			bonusB := partner.CalculateGenerationBonus()
+			bonusA := parent.CalculateGenerationBonus(params)
+			bonusB := partner.CalculateGenerationBonus(params)
 			childGen := baseGen + (bonusA+bonusB)*0.5
 
 			radMult := radiationMult(parent.Loc.X, params)
@@ -516,7 +516,7 @@ func (p *Population) ProcessReproductionQueue(w *world.World, params *Parameters
 		childGenome := AsexualReproduction(parent.Genome, params, radMult, childGen)
 		id := w.AddCreature(offspringLoc)
 		child := NewCreature(id, offspringLoc, childGenome, params)
-		child.Generation = parent.CalculateGenerationBonus()
+		child.Generation = parent.CalculateGenerationBonus(params)
 		child.Tier = GetTierFromGeneration(childGen, params)
 		child.Mass = childMass
 		child.UpdateSize(params)

--- a/v2/simulation/sensor.go
+++ b/v2/simulation/sensor.go
@@ -14,15 +14,15 @@ const (
 	BIAS byte = iota
 	// Current energy relative to maximum: -1 = empty, 0 = half full, 1 = full.
 	ENERGY
-	// Age mapped to [-1, 1]: -1 at birth, 0 at maturity (end of juvenile period), 1 at max age.
-	AGE
 	// Angle to the nearest food item relative to heading [-1, 1]; 0 = directly ahead.
 	NEAREST_FOOD_ANGLE
 	// Distance to the nearest food item normalised by sight range [-1, 1]; 1 = nothing visible.
 	NEAREST_FOOD_DIST
 
 	// -- TIER 2 --
-	
+
+	// Age mapped to [-1, 1]: -1 at birth, 0 at maturity (end of juvenile period), 1 at max age.
+	AGE
 	// Horizontal world position: -1 = left border, 0 = centre, 1 = right border.
 	LOC_X
 	// Vertical world position: -1 = top border, 0 = centre, 1 = bottom border.
@@ -48,10 +48,10 @@ const (
 	PREY_FORWARD
 	// Angle to the nearest lighter creature relative to heading [-1, 1].
 	NEAREST_PREY_ANGLE
-	// Angle to the nearest heavier creature relative to heading [-1, 1].
-	NEAREST_THREAT_ANGLE
 	// Proximity of the nearest heavier creature in the forward FOV; 1 = none visible [-1, 1].
 	THREAT_FORWARD
+	// Angle to the nearest heavier creature relative to heading [-1, 1].
+	NEAREST_THREAT_ANGLE
 	// Current mass as a fraction of genome target mass [0, 1].
 	MASS_FRACTION
 	// 1 if still growing to adult mass, -1 if fully grown.
@@ -60,9 +60,9 @@ const (
 	SATIATION
 	// Rate of stomach content change per digestion tick; positive = absorbing faster than baseline.
 	STOMACH_RATE
-	
+
 	// -- TIER 4 --
-	
+
 	// Bearing to the centre of mass of nearby creatures relative to own heading [-1, 1].
 	POPULATION_LOCAL_CENTRE_OF_MASS
 	// Proximity-weighted density of creatures within sight radius [-1, 1].
@@ -93,6 +93,12 @@ const (
 	LOCAL_FOOD_PER_CAPITA
 
 	SENSOR_COUNT
+)
+
+const (
+	MaxTier1Sensor = 3
+	MaxTier2Sensor = 11
+	MaxTier3Sensor = 21
 )
 
 // Expected creature density

--- a/v2/simulation/simulation.go
+++ b/v2/simulation/simulation.go
@@ -55,7 +55,8 @@ func (s *Simulation) initializePopulation() {
 		if numSaved > 0 && i < maxSeeded {
 			genome = savedGenomes[(i/bubbleSize)%numSaved]
 		} else {
-			genome = MakeRandomGenome(s.Params)
+			// Initialise genomes at tier zero
+			genome = MakeRandomGenome(s.Params, 0)
 		}
 
 		for j := 0; j < bubbleSize; j++ {
@@ -105,14 +106,14 @@ func (s *Simulation) step() {
 	if s.Tick%s.Params.FoodSpawnInterval == 0 {
 		// Spawning food by energy temporarily disabled. Not enough creatures
 		// eat meat and so it energy ends up stagnating in meat.+
-		// deficit := s.Energy - s.TotalEnergy()
-		// if deficit < 0 {
-		// 	deficit = 0
-		// }
-		// energyPerPiece := float64(s.Params.FoodMass) * float64(s.Params.EnergyPerMassUnit)
+		deficit := s.Energy - s.TotalEnergy()
+		if deficit < 0 {
+			deficit = 0
+		}
+		energyPerPiece := float64(s.Params.FoodMass) * float64(s.Params.EnergyPerMassUnit)
 		// number of food items to spawn
-		// n := int(deficit / energyPerPiece)
-		n := s.Params.MaxFood - s.World.PlantCount()
+		n := int(deficit / energyPerPiece)
+		// n := s.Params.MaxFood - s.World.PlantCount()
 		s.World.SpawnPlant(n, s.Params.FountainRadius, s.Params.FoodMass)
 	}
 
@@ -202,6 +203,8 @@ func (s *Simulation) stepCreatureLocal(c *Creature, pending *pendingInstructions
 		c.DrainEnergy(s.Params.RadiationDamagePerTick * massEffect)
 	}
 	c.Digest(s.Params)
+	c.GrowMass(s.Params)
+
 	if c.Energy <= 0 || c.Age > c.MaxAge(s.Params) {
 		pending.death = append(pending.death, DeathInstruction{c})
 		return
@@ -284,18 +287,32 @@ func (s *Simulation) executeActionsLocal(c *Creature, actionLevels []float32, pe
 			c.LastAction = appendActionString(c.LastAction, "Punishing")
 		}
 	}
+
 	if IsActionEnabled(REPRODUCE) {
-		level := actionLevels[REPRODUCE]
-		if math.Abs(float64(level)) > 0.5 {
-			reproThreshold := s.Params.ReproductionEnergyThreshold * c.MaxEnergy(s.Params)
-			if c.Energy >= reproThreshold && c.Age >= c.cachedJuvenilePeriod && float64(c.Mass) >= float64(c.Genome.Mass)*0.9 {
+		currentTier := c.Tier
+		reproThreshold := s.Params.ReproductionEnergyThreshold * c.MaxEnergy(s.Params)
+		isPhysicallyReady := c.Energy >= reproThreshold &&
+			c.Age >= c.cachedJuvenilePeriod &&
+			float64(c.Mass) >= float64(c.Genome.Mass)*0.9 &&
+			float32(c.Genome.MinMass)*2 < float32(c.Genome.Mass)
+		// Reproduction is not introduced until tier 3
+		if currentTier >= 2 {
+			level := actionLevels[REPRODUCE]
+			if math.Abs(float64(level)) > 0.5 && isPhysicallyReady {
 				if c.Genome.ReproductionType == 0 {
 					pending.reproduction = append(pending.reproduction, ReproductionInstruction{Creature: c})
-					c.LastAction = appendActionString(c.LastAction, "Reproducing")
+					c.LastAction = appendActionString(c.LastAction, "Reproducing (Intent)")
 				} else {
 					pending.mate = append(pending.mate, c)
 					c.LastAction = appendActionString(c.LastAction, "Seeking mate")
 				}
+			}
+		} else {
+			// Automatic physiological reproduction
+			if isPhysicallyReady {
+				// Force asexual division for lower tiers to scale population early on
+				pending.reproduction = append(pending.reproduction, ReproductionInstruction{Creature: c})
+				c.LastAction = appendActionString(c.LastAction, "Auto-Splitting")
 			}
 		}
 	}
@@ -475,7 +492,8 @@ func (s *Simulation) SpawnAt(x, y float64) bool {
 	spawnParams := *s.Params
 
 	id := s.World.AddCreature(pos)
-	genome := MakeRandomGenome(&spawnParams)
+	// Initialise genomes at tier zero
+	genome := MakeRandomGenome(&spawnParams, 0)
 	c := NewAdultCreature(id, pos, genome, s.Params)
 	s.Population.Creatures[id] = c
 	s.Population.AddAlive(id)
@@ -487,7 +505,8 @@ func (s *Simulation) SpawnAt(x, y float64) bool {
 // All creatures share the same randomly generated genome. Positions that are walls are skipped.
 func (s *Simulation) SpawnClusterAt(x, y float64, count int) bool {
 	spawnParams := *s.Params
-	genome := MakeRandomGenome(&spawnParams)
+	// Initialise genomes at tier zero
+	genome := MakeRandomGenome(&spawnParams, 0)
 
 	offsets := [][2]float64{{0, 0}, {4, 0}, {-4, 0}, {0, 4}, {0, -4}}
 	spawned := 0
@@ -570,7 +589,7 @@ func (s *Simulation) AverageGeneration() float64 {
 	if count == 0 {
 		return 0
 	}
-	total := 0
+	total := float32(0.0)
 	for _, id := range s.Population.aliveIDs {
 		total += s.Population.Creatures[id].Generation
 	}
@@ -609,6 +628,7 @@ func (s *Simulation) updatePopulationCaches() {
 			FieldOfView:      c.FieldOfView(),
 			Radius:           float64(c.Radius),
 			ReproductionType: c.Genome.ReproductionType,
+			Tier:             c.Tier,
 		})
 	}
 }
@@ -643,8 +663,8 @@ var ResponseCurveLUT [256]float32
 // Initialize at startup
 func InitResponseCurve(params *Parameters) {
 	for i := 0; i < 256; i++ {
-		// Map 0 -> 255 to -1.0 -> 1.0
-		resp := (float32(i) / 127.5) - 1.0
+		// Map index 0 -> 255 directly to a 0.0 -> 1.0 float range
+		resp := float32(i) / 255.0
 		ResponseCurveLUT[i] = calculateResponseCurve(resp, params.ResponseCurveKFactor)
 	}
 }

--- a/v2/simulation/view.go
+++ b/v2/simulation/view.go
@@ -20,6 +20,7 @@ type CreatureView struct {
 	Mass             byte
 	CurrentMass      float64
 	ReproductionType byte // 0 = asexual, 1 = sexual
+	Tier             byte
 }
 
 // FoodView is a read-only snapshot of a food item (plant or meat) for rendering.
@@ -51,7 +52,8 @@ type NeuralNetView struct {
 // CreatureDetailView is a rich snapshot of a single creature for the inspector panel.
 type CreatureDetailView struct {
 	ID               int
-	Generation       int
+	Generation       float32
+	Tier             byte
 	Energy           float32
 	MaxEnergy        float32
 	Age              int
@@ -72,6 +74,7 @@ type CreatureDetailView struct {
 	FoodEfficiency   float32 // fraction of food mass absorbed per bite [0, 1]
 	MeatEfficiency   float32 // fraction of meat mass absorbed per bite [0, 1]
 	ReproductionType byte    // 0 = asexual, 1 = sexual
+	Responsiveness   float32 // current responsiveness multiplier [-1, 1]
 	NeuralNet        NeuralNetView
 }
 
@@ -117,6 +120,7 @@ func (s *Simulation) CreatureDetail(id int) (CreatureDetailView, bool) {
 	return CreatureDetailView{
 		ID:               c.Id,
 		Generation:       c.Generation,
+		Tier:             c.Tier,
 		Energy:           c.Energy,
 		MaxEnergy:        c.MaxEnergy(s.Params),
 		Age:              c.Age,
@@ -140,6 +144,7 @@ func (s *Simulation) CreatureDetail(id int) (CreatureDetailView, bool) {
 		FoodEfficiency:   foodEff,
 		MeatEfficiency:   meatEff,
 		ReproductionType: c.Genome.ReproductionType,
+		Responsiveness:   c.Responsiveness,
 		NeuralNet:        nnView,
 	}, true
 }
@@ -169,6 +174,7 @@ func (s *Simulation) CreatureViews() []CreatureView {
 			Mass:             c.Genome.Mass,
 			CurrentMass:      float64(c.Mass),
 			ReproductionType: c.Genome.ReproductionType,
+			Tier:             c.Tier,
 		})
 	}
 	return views

--- a/v2/ui/neural_net_graph.go
+++ b/v2/ui/neural_net_graph.go
@@ -385,14 +385,16 @@ func nnEdgeColor(w float32) color.RGBA {
 
 func nnSensorName(id byte) string {
 	names := [...]string{
-		"Bias", "Age", "Energy", "Loc X", "Loc Y", "Osc",
-		"LocalDensity", "LocalHeading", "LocalCOM",
-		"PopFwd", "PopCentroid", "FoodFwd", "MeatFwd",
-		"Random", "Satiety", "Heading", "Velocity", "Food Ang",
-		"Food Dist", "Threat", "KinshipLcl", "KinshipFwd", "KinshipNearest",
-		"Mass %", "Blocked", "Prey", "Threat Ang",
-		"Prey Ang", "Wall Prox", "Digest", "Food/Cap",
-		"Juvenile", "EnergyDelta", "Temp", "TempDelta", "Touch",
+		"Bias", "Energy", "NearFoodAngle",
+		"NearFoodDist", "Age", "LocX", "LocY",
+		"Heading", "Velocity", "Osc1", "BlockedFwd",
+		"WallProx", "PlantFwd", "MeatFwd", "PreyFwd",
+		"NearPreyAngle", "ThreatFwd", "NearThreatAngle",
+		"Mass %", "Juvenile", "Satiation", "StomachRate",
+		"LocalCOM", "LocalDensity", "LocalHeading",
+		"PopFwd", "PopDensityFwd", "Touching", "Temp",
+		"TempDelta", "EnergyDelta", "Random", "KinshipLocal",
+		"KinshipNearDist", "KinshipNear", "LocalFoodPerCapita",
 	}
 	if int(id) < len(names) {
 		return names[id]
@@ -402,8 +404,10 @@ func nnSensorName(id byte) string {
 
 func nnActionName(id byte) string {
 	names := [...]string{
-		"Accelerate", "Rotate", "SetOsc", "SetResp",
-		"SetLearn", "Rest", "Attack", "Reward", "Punish", "Mate", "Feed",
+		"Accelerate", "Rotate", "SetOsc",
+		"Rest", "Attack", "Reproduce",
+		"Feed", "SetResp",
+		"SetLearn", "Reward", "Punish",
 	}
 	if int(id) < len(names) {
 		return names[id]

--- a/v2/ui/userinterface.go
+++ b/v2/ui/userinterface.go
@@ -17,8 +17,8 @@ const (
 	menuBarPad     = float32(10)
 	menuBarSpacing = float32(8)
 
-	detailPanelW = float32(210)
-	detailPad    = float32(8)
+	detailPanelW  = float32(210)
+	detailPad     = float32(8)
 	detailSpacing = float32(4)
 
 	leftStackX       = float32(10)
@@ -41,10 +41,10 @@ type UserInterface struct {
 	font *textv2.GoXFace
 	sim  SimulationState
 
-	menuBar    *components.MenuBar
-	leftStack  *LeftPanelStack
-	histGraph  *HistoryGraph
-	histIdx    int
+	menuBar   *components.MenuBar
+	leftStack *LeftPanelStack
+	histGraph *HistoryGraph
+	histIdx   int
 
 	detailIdx int
 	nnIdx     int
@@ -59,15 +59,15 @@ type UserInterface struct {
 	saveFeedbackAt time.Time
 
 	// references so buttons can trigger game-level actions
-	onSaveCreature    func() error
-	onEditCreature    func()
-	onSpawnAtWorld    func(wx, wy float64)
-	onPause           func()
-	onRestart         func()
-	onToggleTheme     func()
-	onCreateGenome    func()
-	onSpawnSaved      func()
-	onToggleSpawn     func()
+	onSaveCreature func() error
+	onEditCreature func()
+	onSpawnAtWorld func(wx, wy float64)
+	onPause        func()
+	onRestart      func()
+	onToggleTheme  func()
+	onCreateGenome func()
+	onSpawnSaved   func()
+	onToggleSpawn  func()
 }
 
 // NewUserInterface constructs the UI, wiring up all interactive elements.
@@ -88,7 +88,7 @@ func NewUserInterface(
 		Label:      "Mut",
 		Font:       font,
 		LabelColor: color.White,
-		Min: 0.0001, Max: 0.2,
+		Min:        0.0001, Max: 0.2,
 		Value: 0.01,
 		OnChange: func(v float64) {
 			sim.SetSpawnMutationRate(float32(v))
@@ -135,6 +135,11 @@ func NewUserInterface(
 		game.savedGenomesPanel.Open()
 	}
 
+	tierBtn := &components.Button{W: 90, H: 24, Label: "Tier: All", Color: components.ColorDefault, LabelColor: color.White, Font: font}
+	tierBtn.OnClick = func() {
+		tierBtn.Label = game.world.CycleTierFilter()
+	}
+
 	mb := &components.MenuBar{
 		H:       menuBarH,
 		Padding: menuBarPad,
@@ -148,6 +153,7 @@ func NewUserInterface(
 	mb.AddButton(spawnRandomBtn)
 	mb.AddButton(createGenomeBtn)
 	mb.AddButton(spawnSavedBtn)
+	mb.AddButton(tierBtn)
 	ui.menuBar = mb
 
 	// ── Left panel stack ──────────────────────────────────────────────────────
@@ -321,7 +327,7 @@ func (ui *UserInterface) buildDetailPanel(d simulation.CreatureDetailView, creat
 	})
 
 	// Generation / Age
-	p.Add(&components.Label{Text: fmt.Sprintf("Generation: %d", d.Generation), Font: ui.font, Color: color.RGBA{180, 220, 255, 255}})
+	p.Add(&components.Label{Text: fmt.Sprintf("Generation: %.2f (Tier: %d)", d.Generation, d.Tier), Font: ui.font, Color: color.RGBA{180, 220, 255, 255}})
 	juvenileStr := "Adult"
 	if d.IsJuvenile {
 		juvenileStr = fmt.Sprintf("Juvenile(%d)", d.JuvenilePeriod-d.Age)
@@ -362,6 +368,17 @@ func (ui *UserInterface) buildDetailPanel(d simulation.CreatureDetailView, creat
 		Max:      float32(1.2),
 		MaxColor: color.RGBA{216, 27, 96, 255},
 		MinColor: color.RGBA{48, 63, 159, 255},
+		Width:    innerW,
+		Centered: true,
+	})
+
+	// Responsiveness
+	p.Add(&components.Label{Text: fmt.Sprintf("Responsiveness: %.02f", d.Responsiveness), Font: ui.font, Color: color.White})
+	p.Add(&components.EnergyBar{
+		Value:    d.Responsiveness,
+		Max:      float32(1),
+		MaxColor: color.RGBA{255, 180, 40, 255},
+		MinColor: color.RGBA{60, 60, 200, 255},
 		Width:    innerW,
 		Centered: true,
 	})

--- a/v2/ui/worldrenderer.go
+++ b/v2/ui/worldrenderer.go
@@ -3,8 +3,10 @@ package ui
 import (
 	"biogo/v2/simulation"
 	"biogo/v2/world"
+	"fmt"
 	"image/color"
 	"math"
+	"sort"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -19,6 +21,7 @@ type creatureAnim struct {
 	mass         float64
 	radius       float32
 	sexual       bool
+	tier         byte
 }
 
 // WorldRenderer handles all world-space rendering: temperature gradient,
@@ -44,6 +47,8 @@ type WorldRenderer struct {
 	isDark           bool
 	lastTickTime     time.Time
 	tickDuration     time.Duration
+
+	tierFilter int // -1 = show all; 0-3 = dim creatures not in this tier
 
 	camDragging   bool
 	camDragMoved  bool
@@ -102,6 +107,7 @@ func NewWorldRenderer(sim SimulationState) *WorldRenderer {
 		vertsPerCircle:   vertsPerCircle,
 		indicesPerCircle: indicesPerCircle,
 		isDark:           true,
+		tierFilter:       -1,
 		circleCreatureVs: make([]ebiten.Vertex, 0, maxPop*vertsPerCircle),
 		sexualCreatureVs: make([]ebiten.Vertex, 0, maxPop*3),
 		sexualCreatureIs: make([]uint16, 0, maxPop*3),
@@ -111,6 +117,40 @@ func NewWorldRenderer(sim SimulationState) *WorldRenderer {
 
 // ToggleDark flips the world background theme.
 func (wr *WorldRenderer) ToggleDark() { wr.isDark = !wr.isDark }
+
+// CycleTierFilter steps through the tiers present in the current population:
+// All → Tier 0 → Tier 1 → ... → All. Returns the new button label.
+func (wr *WorldRenderer) CycleTierFilter() string {
+	tierSet := make(map[int]struct{})
+	for _, anim := range wr.animByID {
+		tierSet[int(anim.tier)] = struct{}{}
+	}
+	tiers := make([]int, 0, len(tierSet))
+	for t := range tierSet {
+		tiers = append(tiers, t)
+	}
+	sort.Ints(tiers)
+
+	if wr.tierFilter == -1 {
+		if len(tiers) > 0 {
+			wr.tierFilter = tiers[0]
+		}
+	} else {
+		next := -1
+		for _, t := range tiers {
+			if t > wr.tierFilter {
+				next = t
+				break
+			}
+		}
+		wr.tierFilter = next
+	}
+
+	if wr.tierFilter == -1 {
+		return "Tier: All"
+	}
+	return fmt.Sprintf("Tier: %d", wr.tierFilter)
+}
 
 // Camera returns a pointer to the camera for external queries (e.g. ScreenToWorld).
 func (wr *WorldRenderer) Camera() *Camera { return &wr.camera }
@@ -216,6 +256,7 @@ func (wr *WorldRenderer) UpdateAnimations(snapshot *simulation.StateSnapshot) ti
 			anim.mass = cv.CurrentMass
 			anim.radius = float32(cv.Radius * bs)
 			anim.sexual = cv.ReproductionType == 1
+			anim.tier = cv.Tier
 		} else {
 			wr.animByID[cv.ID] = &creatureAnim{
 				prevX: screenX, prevY: screenY,
@@ -225,6 +266,7 @@ func (wr *WorldRenderer) UpdateAnimations(snapshot *simulation.StateSnapshot) ti
 				mass:    cv.CurrentMass,
 				radius:  float32(cv.Radius * bs),
 				sexual:  cv.ReproductionType == 1,
+				tier:    cv.Tier,
 			}
 		}
 	}
@@ -311,6 +353,9 @@ func (wr *WorldRenderer) Draw(screen *ebiten.Image, snapshot *simulation.StateSn
 		lerpY := anim.prevY + (anim.curY-anim.prevY)*t
 		cx, cy := float32(lerpX), float32(lerpY)
 		cr, cg, cb, ca := float32(anim.r)/255, float32(anim.g)/255, float32(anim.b)/255, float32(anim.a)/255
+		if wr.tierFilter != -1 && int(anim.tier) != wr.tierFilter {
+			ca *= 0.2
+		}
 
 		if anim.sexual {
 			baseIdx := uint16(len(wr.sexualCreatureVs))


### PR DESCRIPTION
Introduced tiered evolution. The brain complexity is capped for early generations, and as creatures evolve they unlock access to more complex sensors and actions.
changed generation tracking to a float, reward generations based on how much the creature invests in adulthood and mass to child, prevents optimising for spamming children
update MakeRandomGenome to only generate sinks and sources based on tiers
updated nnet creation to fix some pruning bugs and generate based on new tiers
fixed bug in mass growth
fixed bug in response curve
added tier button to filter creatures visually by tier
added tier and generation display to creature display view