### PR TITLE
Fixed mutation to retain parent neurology

### DIFF
--- a/v2/simulation/creature.go
+++ b/v2/simulation/creature.go
@@ -35,7 +35,7 @@ type Creature struct {
 	Loc            world.Position
 	BirthLoc       world.Position
 	Heading        float32 // radians; 0 = east, π/2 = south (screen-down)
-	Speed       float32 // current speed along heading; updated each tick via ACCELERATE action
+	Speed          float32 // current speed along heading; updated each tick via ACCELERATE action
 	Genome         *Genome
 	SightDistance  float32
 	Mass           float32 // tracked body mass; grows toward Genome.Mass each tick via GrowMass
@@ -196,27 +196,27 @@ func (c *Creature) Digest(params *Parameters) {
 		return
 	}
 
+	massNorm := float64(c.Mass) / params.MaxMass
+	// Efficient M^0.75
+	massEffect := math.Sqrt(massNorm * math.Sqrt(massNorm))
+
 	currentCap := c.StomachCapacity(params)
 	var sizeFactor float64
 	if currentCap > 0 {
 		standardCap := float64(params.MaxMass) * 0.2
-		ratio := standardCap / float64(currentCap)
-		// x^0.75 = sqrt(ratio * sqrt(ratio))
+		ratio := float64(currentCap) / standardCap
 		sizeFactor = math.Sqrt(ratio * math.Sqrt(ratio))
 	} else {
-		sizeFactor = 1.0 // Fallback
+		sizeFactor = 1.0
 	}
 
-	massNorm := float64(c.Mass) / params.MaxMass
-	// Efficient M^0.75
-	massEffect := math.Sqrt(massNorm * math.Sqrt(massNorm))
 	digestionRate := params.DigestionRate * massEffect * sizeFactor
 
-	massRatio := c.Mass / float32(params.MaxMass)
-	// Higher mass = lower efficiency.
-	efficiency := 0.95 - (massRatio * 0.25)
+	// Small creatures at 70% baseline, large creatures 95% efficient
+	efficiency := float32(0.75 + (massNorm * 0.20))
 	if c.IsResting {
-		restingBoost := 1.5 + (2.0 * float64(massNorm))
+		// Resting remains a massive booster, especially rewarding for giant temp-regulation
+		restingBoost := 1.5 + (1.5 * massNorm)
 		digestionRate *= restingBoost
 	}
 

--- a/v2/simulation/genome.go
+++ b/v2/simulation/genome.go
@@ -190,6 +190,56 @@ func makeRandomBool() byte {
 	return byte(rand.Uint32() >> 31)
 }
 
+// generateTierExpansionGene creates a new connection that targets the newly unlocked space
+// between the parent's constraints and the child's expanded actions/sensors/ hidden neurons.
+func (g *Genome) generateTierExpansionGene(pBreadth, cBreadth, pSensors, cSensors, pActions, cActions byte) Gene {
+	var gene Gene
+	gene.Weight = utils.MakeRandomByte()
+
+	// Source
+	if rand.Float32() < 0.5 && cBreadth > pBreadth {
+		gene.SourceType = 1
+
+		// Start at the parent's boundary, then add a random value
+		// bounded strictly by the size of the new expansion tier.
+		delta := cBreadth - pBreadth
+		gene.SourceID = pBreadth + (utils.MakeRandomByte() % delta)
+	} else {
+		// Target a Sensor
+		gene.SourceType = 0
+
+		if cSensors > pSensors {
+			// A new sensor was unlocked! Force the connection to read from it.
+			delta := cSensors - pSensors
+			gene.SourceID = pSensors + (utils.MakeRandomByte() % delta)
+		} else {
+			// No new sensors unlocked; fall back to sampling the existing ones uniformly.
+			gene.SourceID = utils.MakeRandomByte() % cSensors
+		}
+	}
+
+	if rand.Float32() < 0.5 && cBreadth > pBreadth {
+		gene.SinkType = 1
+
+		// Offset the index into the new hidden neuron real estate.
+		delta := cBreadth - pBreadth
+		gene.SinkID = pBreadth + (utils.MakeRandomByte() % delta)
+	} else {
+		gene.SinkType = 2
+
+		if cActions > pActions {
+			// A new action was unlocked! Force the connection to drive it.
+			delta := cActions - pActions
+			gene.SinkID = pActions + (utils.MakeRandomByte() % delta)
+		} else {
+			// No new actions unlocked; fall back to sampling the existing ones uniformly.
+			gene.SinkID = utils.MakeRandomByte() % cActions
+		}
+	}
+
+	return gene
+}
+
 // MakeRandomGene creates a random gene
 func MakeRandomGene(allowedSensors, allowedActions, cognitiveBreadth byte) Gene {
 	sourceType := byte(SENSOR)
@@ -312,18 +362,33 @@ func Mutate(g *Genome, p *Parameters, isArtificial bool, mutationMult float32, c
 	rateMultiplier := float32(g.MutationRate) / 128.0
 	mutationRate := p.BaseMutationRate * rateMultiplier * mutationMult
 
+	// Track parent dimentional limits so that we don't lose
+	// the pre-existing constructed brain on tier upgrades
+	parentBreadth := g.CognitiveBreadth
+	parentSensors := getAllowedSensorCount(parentBreadth)
+	parentActions := getAllowedActionCount(parentBreadth)
+
+	// Helper function to "mutate" - i.e. nudge byte in a direction
 	mutateTarget := func(val *byte, min, max byte, strength int) {
 		if rand.Float32() < mutationRate {
 			*val = utils.LerpByte(min, max, nudgeByte(*val, strength))
 		}
 	}
 
+	// Physical attribute mutation
 	mutateTarget(&g.OscPeriod, 0, 255, 15)
 	mutateTarget(&g.SightDistance, 0, 255, 10)
 	mutateTarget(&g.FieldOfView, 0, 255, 10)
 	mutateTarget(&g.Responsiveness, 0, 255, 20)
 	mutateTarget(&g.MutationRate, 1, 255, 5)
 	mutateTarget(&g.Mass, 3, math.MaxUint8, 12)
+	mutateTarget(&g.JuvenilePeriod, 0, 255, 15)
+	mutateTarget(&g.MetabolicRate, 0, 255, 15)
+	mutateTarget(&g.StomachSize, 0, 255, 15)
+	mutateTarget(&g.Neuroplasticity, 0, 255, 10)
+	mutateTarget(&g.LearningThreshold, 0, 255, 10)
+	mutateTarget(&g.MassSplitRatio, 0, 255, 15)
+	mutateTarget(&g.DigestionType, 0, 255, 15)
 
 	maxMinMass := (g.Mass - 1) / 2
 	if maxMinMass < 1 {
@@ -334,24 +399,21 @@ func Mutate(g *Genome, p *Parameters, isArtificial bool, mutationMult float32, c
 	}
 	mutateTarget(&g.MinMass, 1, maxMinMass, 8)
 
+	// Chance to flip reproduction type
+	// TODO(): Need to consider this, because becoming the only sexual
+	// creature in your species is probably a sad and frustrating existence.
 	if rand.Float32() < mutationRate {
 		g.ReproductionType ^= 1
 	}
 
+	// New tier constraints and cognitive breadth
 	minTierBreadth, maxTierBreadth := getTierBoundaries(childGeneration, p)
 	mutateTarget(&g.CognitiveBreadth, minTierBreadth, maxTierBreadth, 5)
+
 	// Force SynapticDensity bounds to slide up with the tier scaling
 	minDensity := utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, minTierBreadth)
 	maxDensity := utils.LerpByte(p.MinSynapticDensity, p.MaxSynapticDensity, maxTierBreadth)
 	mutateTarget(&g.SynapticDensity, minDensity, maxDensity, 5)
-
-	mutateTarget(&g.JuvenilePeriod, 0, 255, 15)
-	mutateTarget(&g.MetabolicRate, 0, 255, 15)
-	mutateTarget(&g.StomachSize, 0, 255, 15)
-	mutateTarget(&g.Neuroplasticity, 0, 255, 10)
-	mutateTarget(&g.LearningThreshold, 0, 255, 10)
-	mutateTarget(&g.MassSplitRatio, 0, 255, 15)
-	mutateTarget(&g.DigestionType, 0, 255, 15)
 
 	allowedSensors := getAllowedSensorCount(g.CognitiveBreadth)
 	allowedActions := getAllowedActionCount(g.CognitiveBreadth)
@@ -369,46 +431,39 @@ func Mutate(g *Genome, p *Parameters, isArtificial bool, mutationMult float32, c
 					g.Brain[j].SinkType = 2
 				}
 			case chance < 0.15:
-				if g.Brain[j].SourceType == 1 && g.CognitiveBreadth > 0 { // NEURON
-					g.Brain[j].SourceID = utils.MakeRandomByte() % g.CognitiveBreadth
-				} else { // SENSOR
-					g.Brain[j].SourceID = utils.MakeRandomByte() % allowedSensors
+				// Protected mapping using parent boundaries
+				if g.Brain[j].SourceType == 1 && parentBreadth > 0 {
+					g.Brain[j].SourceID = utils.MakeRandomByte() % parentBreadth
+				} else {
+					g.Brain[j].SourceID = utils.MakeRandomByte() % parentSensors
 				}
 			case chance < 0.20:
-				if g.Brain[j].SinkType == 1 && g.CognitiveBreadth > 0 { // NEURON
-					g.Brain[j].SinkID = utils.MakeRandomByte() % g.CognitiveBreadth
-				} else { // ACTION
-					g.Brain[j].SinkID = utils.MakeRandomByte() % allowedActions
+				if g.Brain[j].SinkType == 1 && parentBreadth > 0 {
+					g.Brain[j].SinkID = utils.MakeRandomByte() % parentBreadth
+				} else {
+					g.Brain[j].SinkID = utils.MakeRandomByte() % parentActions
 				}
 			default:
 				g.Brain[j].Weight = nudgeByte(g.Brain[j].Weight, 25)
 			}
 		}
 	}
+
 	// Brain expansion padding loop: fills vacant structural space when SynapticDensity scales upwards.
 	diff := int(g.SynapticDensity) - len(g.Brain)
 	if diff > 0 {
 		for i := 0; i < diff; i++ {
-			if len(g.Brain) > 0 && rand.Float32() < 0.8 {
-				newGene := g.Brain[rand.Intn(len(g.Brain))]
-				if rand.Float32() < 0.5 {
-					if newGene.SourceType == 1 && g.CognitiveBreadth > 0 {
-						newGene.SourceID = utils.MakeRandomByte() % g.CognitiveBreadth
-					} else {
-						newGene.SourceID = utils.MakeRandomByte() % allowedSensors
-					}
-				} else {
-					if newGene.SinkType == 1 && g.CognitiveBreadth > 0 {
-						newGene.SinkID = utils.MakeRandomByte() % g.CognitiveBreadth
-					} else {
-						newGene.SinkID = utils.MakeRandomByte() % allowedActions
-					}
-				}
-				newGene.Weight = nudgeByte(newGene.Weight, 40)
-				g.Brain = append(g.Brain, newGene)
+			var newGene Gene
+
+			// Allocate 75% of new connections directly to newly discovered tier capabilities
+			if (g.CognitiveBreadth > parentBreadth || allowedSensors > parentSensors || allowedActions > parentActions) && rand.Float32() < 0.75 {
+				newGene = g.generateTierExpansionGene(parentBreadth, g.CognitiveBreadth, parentSensors, allowedSensors, parentActions, allowedActions)
 			} else {
-				g.Brain = append(g.Brain, MakeRandomGene(allowedSensors, allowedActions, g.CognitiveBreadth))
+				// 25% is random connection
+				newGene = MakeRandomGene(allowedSensors, allowedActions, g.CognitiveBreadth)
 			}
+
+			g.Brain = append(g.Brain, newGene)
 		}
 	}
 	g.recomputeBytes()

--- a/v2/simulation/genome.go
+++ b/v2/simulation/genome.go
@@ -306,15 +306,12 @@ func nudgeByte(val byte, strength int) byte {
 	return byte(newVal)
 }
 
-// Mutate randomly mutates genes in the genome at a rate of p.BaseMutationRate * g.MutationRate * radiationMult.
-// Pass radiationMult=1.0 for normal reproduction; pass params.RadiationMutationMultiplier for irradiated parents.
-func Mutate(g *Genome, p *Parameters, isArtificial bool, radiationMult float32, childGeneration float32) {
+// Mutate randomly mutates genes in the genome at a rate of p.BaseMutationRate * g.MutationRate * mutationMult.
+// Pass mutationMult=1.0 for normal reproduction; pass params.RadiationMutationMultiplier for irradiated parents.
+func Mutate(g *Genome, p *Parameters, isArtificial bool, mutationMult float32, childGeneration float32) {
 	rateMultiplier := float32(g.MutationRate) / 128.0
-	mutationRate := p.BaseMutationRate * rateMultiplier * radiationMult
+	mutationRate := p.BaseMutationRate * rateMultiplier * mutationMult
 
-	if isArtificial {
-		mutationRate = p.SpawnMutationRate * float32(g.MutationRate)
-	}
 	mutateTarget := func(val *byte, min, max byte, strength int) {
 		if rand.Float32() < mutationRate {
 			*val = utils.LerpByte(min, max, nudgeByte(*val, strength))
@@ -435,8 +432,8 @@ func pickGene(a, b Gene) Gene {
 // by mutation. Each header byte is drawn independently from either parent. Brain
 // genes in the overlapping range are drawn from either parent; excess genes from
 // the longer parent survive with 50% probability.
-// radiationMult amplifies the mutation rate; pass 1.0 for normal conditions.
-func Crossover(g1, g2 *Genome, p *Parameters, radiationMult float32, childGeneration float32) *Genome {
+// mutationMult amplifies the mutation rate; pass 1.0 for normal conditions.
+func Crossover(g1, g2 *Genome, p *Parameters, mutationMult float32, childGeneration float32) *Genome {
 	child := &Genome{
 		OscPeriod:         pickByte(g1.OscPeriod, g2.OscPeriod),
 		SightDistance:     pickByte(g1.SightDistance, g2.SightDistance),
@@ -508,22 +505,22 @@ func Crossover(g1, g2 *Genome, p *Parameters, radiationMult float32, childGenera
 	// Align SynapticDensity with the actual brain length so Mutate does not
 	// immediately re-grow the brain beyond what crossover intended.
 	child.SynapticDensity = byte(targetLen)
-	mutationChance := 0.01 * radiationMult
+	mutationChance := 0.01 * mutationMult
 	if rand.Float32() < mutationChance {
-		Mutate(child, p, false, radiationMult, childGeneration)
+		Mutate(child, p, false, mutationMult, childGeneration)
 	}
 	return child
 }
 
 // AsexualReproduction creates a deep copy of the parent genome then mutates it.
-// radiationMult amplifies the mutation rate; pass 1.0 for normal conditions.
-func AsexualReproduction(parent *Genome, p *Parameters, radiationMult float32, childGeneration float32) *Genome {
+// mutationMult amplifies the mutation rate; pass 1.0 for normal conditions.
+func AsexualReproduction(parent *Genome, p *Parameters, mutationMult float32, childGeneration float32) *Genome {
 	child := parent.Copy()
 	minTierBreadth, _ := getTierBoundaries(childGeneration, p)
 	if child.CognitiveBreadth < minTierBreadth {
 		child.CognitiveBreadth = minTierBreadth // Push up to the new tier minimum
 	}
-	Mutate(child, p, false, radiationMult, childGeneration)
+	Mutate(child, p, false, mutationMult, childGeneration)
 	return child
 }
 

--- a/v2/simulation/parameters.go
+++ b/v2/simulation/parameters.go
@@ -31,8 +31,7 @@ type Parameters struct {
 	ResponseCurveKFactor     float32
 
 	// Mutation
-	BaseMutationRate  float32
-	SpawnMutationRate float32
+	BaseMutationRate float32
 
 	// Age / lifecycle
 	BaseMaxAge        int
@@ -129,7 +128,6 @@ func DefaultParams() *Parameters {
 		MaxFieldOfView:              180,
 		ResponseCurveKFactor:        2,
 		BaseMutationRate:            0.005,
-		SpawnMutationRate:           0.5,
 		BaseMaxAge:                  25000,
 		MinJuvenilePeriod:           300,
 		MaxJuvenilePeriod:           1000,

--- a/v2/simulation/simulation.go
+++ b/v2/simulation/simulation.go
@@ -486,6 +486,7 @@ func (s *Simulation) pairMates(candidates []*Creature) {
 	}
 }
 
+func (s *Simulation) SetMaxFood(v int)                { s.Params.MaxFood = v }
 func (s *Simulation) SetFoodRandomFraction(v float64) { s.Params.FoodRandomFraction = v }
 func (s *Simulation) SetFountainDriftSpeed(v float64) { s.Params.FountainDriftSpeed = v }
 func (s *Simulation) SetFountainRadius(v float64)     { s.Params.FountainRadius = v }
@@ -651,6 +652,10 @@ func partitionIDs(ids []int, n int) [][]int {
 	size := (len(ids) + n - 1) / n
 	for i := range batches {
 		start := i * size
+		if start >= len(ids) {
+			batches[i] = nil
+			continue
+		}
 		end := start + size
 		if end > len(ids) {
 			end = len(ids)

--- a/v2/simulation/simulation.go
+++ b/v2/simulation/simulation.go
@@ -486,12 +486,6 @@ func (s *Simulation) pairMates(candidates []*Creature) {
 	}
 }
 
-// SetSpawnMutationRate sets the minimum mutation rate applied when artificially
-// spawning creatures to maintain the minimum population.
-func (s *Simulation) SetSpawnMutationRate(rate float32) {
-	s.Params.SpawnMutationRate = rate
-}
-
 func (s *Simulation) SetFoodRandomFraction(v float64) { s.Params.FoodRandomFraction = v }
 func (s *Simulation) SetFountainDriftSpeed(v float64) { s.Params.FountainDriftSpeed = v }
 func (s *Simulation) SetFountainRadius(v float64)     { s.Params.FountainRadius = v }

--- a/v2/ui/food_dropdown.go
+++ b/v2/ui/food_dropdown.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	fdPanelW   = float32(300)
-	fdPad      = float32(8)
-	fdTitleH   = float32(20)
-	fdSliderH  = float32(24)
+	fdPanelW    = float32(300)
+	fdPad       = float32(8)
+	fdTitleH    = float32(20)
+	fdSliderH   = float32(24)
 	fdSliderGap = float32(6)
 )
 
@@ -34,6 +34,17 @@ func newFoodDropdown(font *textv2.GoXFace, trigger *components.Button, sim Simul
 	trackW := sw - trackOff
 
 	sliders := []*components.Slider{
+		{
+			W: sw, H: fdSliderH,
+			TrackOffX: trackOff, TrackW: trackW,
+			Font: font, LabelColor: color.White,
+			Min: 0, Max: 200000,
+			Value: float64(p.MaxFood),
+			FormatFunc: func(v float64) string {
+				return fmt.Sprintf("Max Food: %d", int(math.Round(v)))
+			},
+			OnChange: func(v float64) { sim.SetMaxFood(int(math.Round(v))) },
+		},
 		{
 			W: sw, H: fdSliderH,
 			TrackOffX: trackOff, TrackW: trackW,

--- a/v2/ui/game.go
+++ b/v2/ui/game.go
@@ -35,6 +35,7 @@ type SimulationState interface {
 	CreatureDetail(id int) (simulation.CreatureDetailView, bool)
 	SetFoodRandomFraction(v float64)
 	SetFountainCount(n int)
+	SetMaxFood(n int)
 	SetFountainDriftSpeed(v float64)
 	SetFountainRadius(v float64)
 	SpawnAt(x, y float64) bool

--- a/v2/ui/game.go
+++ b/v2/ui/game.go
@@ -33,7 +33,6 @@ type SimulationState interface {
 	TotalEnergy() float64
 	TargetEnergy() float64
 	CreatureDetail(id int) (simulation.CreatureDetailView, bool)
-	SetSpawnMutationRate(rate float32)
 	SetFoodRandomFraction(v float64)
 	SetFountainCount(n int)
 	SetFountainDriftSpeed(v float64)
@@ -75,6 +74,7 @@ type Game struct {
 	snapshot           simulation.StateSnapshot // persistent; backing slices reused each tick
 	currentSnapshot    *simulation.StateSnapshot
 	tickDuration       time.Duration
+	uiConsumedClick    bool
 
 	// Held by UI for input routing (updated each frame by UserInterface)
 	spawnMutSlider    *components.Slider
@@ -156,17 +156,21 @@ func (g *Game) Update() error {
 	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
 		if g.genomeEditor != nil && g.genomeEditor.visible {
 			g.genomeEditor.HandleInput(mx, my)
+			g.uiConsumedClick = true
 		} else if g.savedGenomesPanel != nil && g.savedGenomesPanel.visible {
 			g.savedGenomesPanel.HandleInput(mx, my)
+			g.uiConsumedClick = true
 		} else if g.ui.HandleClick(mx, my) {
-			// UI consumed the click
+			g.uiConsumedClick = true
 		} else if g.spawnPlacing {
+			g.uiConsumedClick = false
 			sw, sh := ebiten.WindowSize()
 			cam := g.world.Camera()
 			wx, wy := cam.ScreenToWorld(float64(mx), float64(my), float64(sw), float64(sh))
 			bs := float64(UnitSize)
 			g.sim.SpawnClusterAt(wx/bs, wy/bs, 5)
 		} else {
+			g.uiConsumedClick = false
 			g.world.StartCameraDrag(mx, my)
 		}
 	}
@@ -174,12 +178,13 @@ func (g *Game) Update() error {
 	// Mouse-up
 	if inpututil.IsMouseButtonJustReleased(ebiten.MouseButtonLeft) {
 		moved := g.world.StopCameraDrag()
-		if !moved {
+		if !g.uiConsumedClick && !moved {
 			sx, sy := g.world.CamDragStartPos()
 			sw, sh := ebiten.WindowSize()
 			newID := g.world.TrySelectCreature(sx, sy, sw, sh, g.selectedCreatureID)
 			g.selectedCreatureID = newID
 		}
+		g.uiConsumedClick = false
 	}
 
 	if inpututil.IsKeyJustPressed(ebiten.KeyEscape) {

--- a/v2/ui/userinterface.go
+++ b/v2/ui/userinterface.go
@@ -92,21 +92,6 @@ func NewUserInterface(
 		saveCreatureID: -1,
 	}
 
-	// ── Mutation-rate slider ──────────────────────────────────────────────────
-	mutSlider := &components.Slider{
-		W: 240, H: 24,
-		TrackOffX: 135, TrackW: 100,
-		Label:      "Mut",
-		Font:       font,
-		LabelColor: color.White,
-		Min:        0.0001, Max: 0.2,
-		Value: 0.01,
-		OnChange: func(v float64) {
-			sim.SetSpawnMutationRate(float32(v))
-		},
-	}
-	game.spawnMutSlider = mutSlider
-
 	// ── Menu bar buttons ─────────────────────────────────────────────────────
 	pauseBtn := &components.Button{W: 80, H: 24, Label: "Pause", Color: components.ColorButtonRed, LabelColor: color.White, Font: font}
 	pauseBtn.OnClick = func() {
@@ -162,7 +147,6 @@ func NewUserInterface(
 	mb.AddButton(pauseBtn)
 	mb.AddButton(restartBtn)
 	mb.AddButton(themeBtn)
-	mb.AddSlider(mutSlider)
 	mb.AddButton(spawnRandomBtn)
 	mb.AddButton(createGenomeBtn)
 	mb.AddButton(spawnSavedBtn)


### PR DESCRIPTION
When creatures "upgrade" a tier, mutation now preserves the existing parent neurology so they don't suddenly gain random brains and die. 
Updated Digest to stop punishing large creatures, now they are more efficient at digesting food. 
Fixed panic due to slice index out of range